### PR TITLE
Build rpm for centos 9 and 10

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,14 +1,12 @@
 .PHONY: installdeps srpm git_config_pre
 
 installdeps:
-	dnf -y install git make autoconf automake gcc
-	dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/fedora-35-x86_64/ install -y ovirt-engine-nodejs-modules
+	dnf -y install git make autoconf automake python3-devel rpm-build gettext-devel
 
 git_config_pre:
 	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
 	# git commands won't work
-	$(eval REPO_DIR=$(shell pwd))
-	git config --global --add safe.directory ${REPO_DIR}
+	git config --global --add safe.directory "$(shell pwd)"
 
 srpm: installdeps git_config_pre
 	./automation/build-artifacts.sh copr

--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -5,26 +5,41 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
-  build-el8:
-
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: centos-stream-9
+            container-name: el9stream
+          - name: centos-stream-10
+            container-name: el10stream
+
     container:
-      image: quay.io/ovirt/buildcontainer:el8stream
+      image: quay.io/ovirt/buildcontainer:${{ matrix.container-name }}
 
     steps:
+    - name: Trust repository
+      run: git config --global --add safe.directory "$(pwd)"
+    
+    - name: Checkout sources
+      uses: ovirt/checkout-action@main
+
     - name: Install dependencies
-      run: dnf install -y --setopt=tsflags=nodocs autoconf automake createrepo_c dnf dnf-plugins-core dnf-plugin-versionlock dnf-utils gettext-devel git make python3-coverage python3-pycodestyle python3-pyflakes rpm-build gettext python3-devel gcc ovirt-engine-nodejs-modules
+      run: dnf install -y autoconf automake gettext-devel git make rpm-build gettext python3-devel ovirt-engine-nodejs-modules python3-pip
 
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - name: Install python packages
+      run: pip install coverage pycodestyle pyflakes
 
-    - run: automation/check-patch.sh
+    - name: Check patch
+      run: automation/check-patch.sh
       # TODO: Split to separate steps?
 
     - name: Upload artifacts
-      uses: ovirt/upload-rpms-action@v2
+      uses: ovirt/upload-rpms-action@main
       with:
         directory: exported-artifacts/

--- a/cockpit-ovirt.spec.in
+++ b/cockpit-ovirt.spec.in
@@ -14,7 +14,7 @@ Version:        @PACKAGE_RPM_VERSION@
 Release:        @PACKAGE_RPM_RELEASE@%{?release_suffix}%{?checkout}%{?dist}
 Summary:        Dashboard for Cockpit based on %{product}
 License:        ASL 2.0
-URL:            https://gerrit.ovirt.org/gitweb?p=cockpit-ovirt.git;a=summary
+URL:            https://github.com/oVirt/cockpit-ovirt
 Source0:        http://resources.ovirt.org/pub/src/%{name}/%{source_basename}.tar.gz
 
 

--- a/cockpit-ovirt.spec.in
+++ b/cockpit-ovirt.spec.in
@@ -38,6 +38,9 @@ BuildRequires:	gettext-devel
 Summary:        Dashboard for Cockpit based on %{product}
 BuildArch:      noarch
 
+BuildRequires:  make
+BuildRequires:  rpm-build
+
 Requires:       cockpit
 Requires:       cockpit-storaged
 Requires:       ovirt-hosted-engine-setup >= 2.6.1

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AC_SUBST([PACKAGE_RPM_RELEASE])
 AC_SUBST([PLUGINNAME], ['oVirt Cockpit Plugin'])
 
 AC_SUBST([COMMIT],
-         [$( git ls-remote http://gerrit.ovirt.org/cockpit-ovirt.git |
+         [$( git ls-remote https://github.com/oVirt/cockpit-ovirt |
              grep $PACKAGE_TARNAME-$PACKAGE_RPM_VERSION-$PACKAGE_RPM_RELEASE |
              awk '{print $1}' )])
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,10 +8,10 @@
     "lint": "eslint src --ext js,jsx",
     "lint:fix": "eslint src --fix --ext js,jsx",
     "test": "yarn lint",
-    "dev": "NODE_ENV=development webpack --progress",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development webpack --progress",
     "dev:watch": "yarn dev --watch",
     "prebuild": "yarn test",
-    "build": "NODE_ENV=production webpack --progress"
+    "build": "NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production webpack --progress"
   },
   "repository": {
     "type": "git",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://gerrit.ovirt.org/cockpit-ovirt"
+    "url": "https://github.com/oVirt/cockpit-ovirt"
   },
   "keywords": [
     "Cockpit",


### PR DESCRIPTION
* clean up workflow to work for rpm creation of centos 9 and 10
* Simplify makefile
* Add node options to ensure build succeeds while webpack version 4 is used
* drop centos 8 due to EOL